### PR TITLE
Juniper fixes

### DIFF
--- a/config-sample.py
+++ b/config-sample.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from passlib.hash import sha512_crypt
 import hashlib
 
-f = open('/scripts/swboot/switchconfig/config.yaml', 'r')
+f = open(os.path.join(os.path.dirname(sys.argv[0]), '/scripts/swboot/switchconfig/config.yaml'), 'r')
 yaml_conf = yaml.safe_load(f)
 
 # Note: To add new variables, the generate function will need to 

--- a/config-sample.py
+++ b/config-sample.py
@@ -2,13 +2,15 @@ import config
 import ipcalc
 import sqlite3
 import sys
+import os
 import tempita
 import yaml
 from tempita import bunch
 from collections import namedtuple
+from passlib.hash import sha512_crypt
 import hashlib
 
-f = open('switchconfig/config.yaml', 'r')
+f = open('/scripts/swboot/switchconfig/config.yaml', 'r')
 yaml_conf = yaml.safe_load(f)
 
 # Note: To add new variables, the generate function will need to 
@@ -130,7 +132,9 @@ def generate(switch, model_id):
             wifi_switches=config.wifi_switches,
             wifi_vlanid=config.wifi_vlanid,
             password=config.password,
+            password_sha512=sha512_crypt.hash(config.password),
             enable=config.enable,
+            enable_sha512=sha512_crypt.hash(config.enable),
             radius=config.radius,
             snmp_ro=config.snmp_ro,
             snmp_rw=hashlib.sha1((config.snmp_salt + mgmt['ip']).encode()).hexdigest(),
@@ -142,8 +146,8 @@ def generate(switch, model_id):
             )
   # We make the Juniper config a script, to be able to add the crontab.
   if "Juniper" in model_id:
-	  jcfg = tempita.Template(open('juniper.sh.template').read())
-	  cfg_subbed = jcfg.substitute(config=cfg_subbed)
+    jcfg = tempita.Template(open(os.path.join(os.path.dirname(sys.argv[0]), 'juniper.sh.template')).read())
+    cfg_subbed = jcfg.substitute(config=cfg_subbed)
   return cfg_subbed
 
 def parse_metadata(switch):

--- a/config-sample.py
+++ b/config-sample.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from passlib.hash import sha512_crypt
 import hashlib
 
-f = open(os.path.join(os.path.dirname(sys.argv[0]), '/scripts/swboot/switchconfig/config.yaml'), 'r')
+f = open(os.path.join(os.path.dirname(sys.argv[0]), 'switchconfig/config.yaml'), 'r')
 yaml_conf = yaml.safe_load(f)
 
 # Note: To add new variables, the generate function will need to 

--- a/dhcp-hook.py
+++ b/dhcp-hook.py
@@ -10,7 +10,9 @@ db = redis.Redis()
 if sys.argv[1] == "commit":
   swMac = sys.argv[2]
   swIp = sys.argv[3]
-  swName = sys.argv[4]
+  # Remove the VLAN name from Juniper's name.
+  # Example: "D55-A:667" -> "D55-A"
+  swName = re.sub(r'([^:]+):.*$', r'\1', sys.argv[4])
   # Remove the serial number from Juniper's vendor-class-identifier.
   # Example: "Juniper-ex3400-24t-AB1234567890" -> "Juniper-ex3400-24t"
   swClient = re.sub(r'(Juniper.*)-[^-]+$', r'\1', sys.argv[5])

--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -17,7 +17,9 @@ filename "network-confg";
 on commit {
   set agentType = binary-to-ascii(10, 8, "", substring(option agent.circuit-id, 0, 1));
   set agentLength = binary-to-ascii(10, 8, "", substring(option agent.circuit-id, 1, 1));
-  if agentType = "0" {
+  if substring(option vendor-class-identifier, 0, 7) = "Juniper" {
+    set swName = pick-first-value(substring(option agent.circuit-id, 0, 10), "None");
+  } elsif agentType = "0" {
     set swName = pick-first-value(binary-to-ascii(16, 8, ":", substring(option agent.circuit-id, 4, 2)), "None");
   } else {
     set swName = pick-first-value(substring(option agent.circuit-id, 2, 10), "None");

--- a/juniper.sh.template
+++ b/juniper.sh.template
@@ -5,6 +5,6 @@ fullconfig=$(cat << "ENDOFCONFIG"
 ENDOFCONFIG
 )
 echo "$fullconfig" > /tmp/dhtech.config
-echo '@reboot sleep 30; cli -c "configure private;set chassis auto-image-upgrade;commit"' > /tmp/dhtech.cron
+echo '@reboot sleep 30; cli -c "configure private;set chassis auto-image-upgrade;delete vlans management l3-interface;set vlans default l3-interface irb.0;commit"' > /tmp/dhtech.cron
 crontab /tmp/dhtech.cron
 cli -c "configure private;delete;load merge /tmp/dhtech.config;commit"


### PR DESCRIPTION
Fixed Juniper cronjob.
Include all of Juniper opt82 name.
Hash Juniper password in script instead of template.
Fixed a relative path.