### PR TITLE
Expo access switches

### DIFF
--- a/config-sample.py
+++ b/config-sample.py
@@ -54,6 +54,11 @@ static_files = {}
 for sf in yaml_conf['static_files']:
   static_files.update(sf)
 
+# Folder containing static configurations to be served as-is by switchboot (ACCESS;)
+static_configs = None
+if "static_configs" in yaml_conf:
+    static_configs = yaml_conf["static_configs"]
+
 
 # ===============================================================
 # Do not change below this if you do not know what you're doing!

--- a/dhcp-hook.py
+++ b/dhcp-hook.py
@@ -10,9 +10,15 @@ db = redis.Redis()
 if sys.argv[1] == "commit":
   swMac = sys.argv[2]
   swIp = sys.argv[3]
-  # Remove the VLAN name from Juniper's name.
-  # Example: "TABLE; D55-A:667" -> "D55-A"
-  swName = re.sub(r'TABLE; ([^:]+):.*$', r'\1', sys.argv[4])
+  #Parse switch type + remove vlan from the circuit ID
+  #Example : "TABLE; D55-A:667" -> "TABLE" "D55-A"
+  m = re.search(r"^([^;]+);\s([^:]+):.*$", table[4])
+  if m:
+    swType = m.group(1)
+    swName = m.group(2)
+    db.set('type-{}'.format(swIp), swType)
+  else:
+    swName = table[4]
   # Remove the serial number from Juniper's vendor-class-identifier.
   # Example: "Juniper-ex3400-24t-AB1234567890" -> "Juniper-ex3400-24t"
   swClient = re.sub(r'(Juniper.*)-[^-]+$', r'\1', sys.argv[5])

--- a/dhcp-hook.py
+++ b/dhcp-hook.py
@@ -12,13 +12,13 @@ if sys.argv[1] == "commit":
   swIp = sys.argv[3]
   #Parse switch type + remove vlan from the circuit ID
   #Example : "TABLE; D55-A:667" -> "TABLE" "D55-A"
-  m = re.search(r"^([^;]+);\s([^:]+):.*$", table[4])
+  m = re.search(r"^([^;]+);\s([^:]+):.*$", sys.argv[4])
   if m:
     swType = m.group(1)
     swName = m.group(2)
     db.set('type-{}'.format(swIp), swType)
   else:
-    swName = table[4]
+    swName = sys.argv[4]
   # Remove the serial number from Juniper's vendor-class-identifier.
   # Example: "Juniper-ex3400-24t-AB1234567890" -> "Juniper-ex3400-24t"
   swClient = re.sub(r'(Juniper.*)-[^-]+$', r'\1', sys.argv[5])

--- a/dhcpd.conf
+++ b/dhcpd.conf
@@ -50,11 +50,35 @@ class "cisco-switch" {
            (substring(option vendor-class-identifier, 0, 7) = "Juniper");
 }
 
-subnet 192.168.0.0 netmask 255.255.252.0 {
+subnet 192.168.0.0 netmask 255.255.255.0 {
   pool {
     allow members of "cisco-switch";
-    range 192.168.1.10  192.168.3.250;
+    range 192.168.0.10  192.168.0.250;
     option routers 192.168.0.1;
+  }
+}
+
+subnet 192.168.1.0 netmask 255.255.255.0 {
+  pool {
+    allow members of "cisco-switch";
+    range 192.168.1.10  192.168.1.250;
+    option routers 192.168.1.1;
+  }
+}
+
+subnet 192.168.2.0 netmask 255.255.255.0 {
+  pool {
+    allow members of "cisco-switch";
+    range 192.168.2.10  192.168.2.250;
+    option routers 192.168.2.1;
+  }
+}
+
+subnet 192.168.3.0 netmask 255.255.255.0 {
+  pool {
+    allow members of "cisco-switch";
+    range 192.168.3.10  192.168.3.250;
+    option routers 192.168.3.1;
   }
 }
 

--- a/swhttpd.py
+++ b/swhttpd.py
@@ -36,9 +36,9 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
       if not sw_type or sw_type == "TABLE":
           f.write(config.generate(switch, model).encode())
       elif sw_type == "ACCESS":
-          with open(config.static_configs."/".switch.".txt") as s:
+          with open(config.static_configs + "/" + switch + ".txt", "rt") as s:
               for line in s:
-                  f.write(line)
+                  f.write(line.encode())
 
       content_length = f.tell()
       f.seek(0)

--- a/swhttpd.py
+++ b/swhttpd.py
@@ -24,6 +24,7 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
     db = redis.Redis()
     switch = db.get(self.client_address[0]).decode()
     model = db.get('client-{}'.format(self.client_address[0])).decode()
+    sw_type = db.get('type-{}'.format(self.client_address[0])).decode()
     if switch == None or model == None:
       log("Switch not found:", self.client_address[0])
       self.send_error(404, "File not found")
@@ -32,7 +33,13 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
       log("Generating Juniper config for",
           self.client_address[0], "name =", switch)
       f = tempfile.TemporaryFile()
-      f.write(config.generate(switch, model).encode())
+      if not sw_type or sw_type == "TABLE":
+          f.write(config.generate(switch, model).encode())
+      elif sw_type == "ACCESS":
+          with open(config.static_configs."/".switch.".txt") as s:
+              for line in s:
+                  f.write(line)
+
       content_length = f.tell()
       f.seek(0)
 

--- a/swhttpd.py
+++ b/swhttpd.py
@@ -24,7 +24,9 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
     db = redis.Redis()
     switch = db.get(self.client_address[0]).decode()
     model = db.get('client-{}'.format(self.client_address[0])).decode()
-    sw_type = db.get('type-{}'.format(self.client_address[0])).decode()
+    sw_type = db.get('type-{}'.format(self.client_address[0]))
+    if sw_type:
+        sw_type = sw_type.decode()
     if switch == None or model == None:
       log("Switch not found:", self.client_address[0])
       self.send_error(404, "File not found")
@@ -33,12 +35,26 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
       log("Generating Juniper config for",
           self.client_address[0], "name =", switch)
       f = tempfile.TemporaryFile()
-      if not sw_type or sw_type == "TABLE":
+      if sw_type == "TABLE":
           f.write(config.generate(switch, model).encode())
       elif sw_type == "ACCESS":
-          with open(config.static_configs + "/" + switch + ".txt", "rt") as s:
-              for line in s:
-                  f.write(line.encode())
+          filename = config.static_configs + "/" + switch.lower() + ".txt"
+          try:
+              with open(filename, "rt") as s:
+                  for line in s:
+                      f.write(line.encode())
+          except FileNotFoundError as err:
+              log("File ", filename, " not found")
+              self.send_error(404, "File not found")
+              return None
+          except Exception as ex:
+              log("Error occurred : ", str(ex))
+              self.send_error(500, "Unknown error")
+              return None
+      else:
+          log("Unknown switch type.")
+          self.send_error(404, "File not found")
+          return None
 
       content_length = f.tell()
       f.seek(0)
@@ -74,8 +90,13 @@ class swbootHttpHandler(http.server.SimpleHTTPRequestHandler):
     pass
 
 class swbootTCPServer(socketserver.ForkingTCPServer):
-  def server_bind(self):
-    self.socket.bind(self.server_address)
+
+  allow_reuse_address = True
+
+  def __init__(self, address, request_handler_class):
+    self.address = address
+    self.request_handler_class = request_handler_class
+    super().__init__(self.address, self.request_handler_class)
 
 log("swhttpd started")
 
@@ -89,5 +110,4 @@ except KeyboardInterrupt:
   sys.stderr.write("\n")
 except Exception as err:
   sys.stderr.write("Something went wrong: %s\n" % err)
-
 

--- a/swtftpd.py
+++ b/swtftpd.py
@@ -147,6 +147,20 @@ def file_callback(file_to_transfer, raddress, rport):
     if (model in config.models) and ('image' in config.models[model]):
       return file(config.models[model]['image'])
 
+  sw_type = db.get('type-%s' % raddress).decode()
+  if sw_type and sw_type == "ACCESS":
+    if file_to_transfer.lower().endswith("-confg"):
+      with open(config.static_configs."/".switch.".txt") as s:
+        f = tempfile.TemporaryFile()
+        log("Sending static config for", raddress,"config =", switch)
+        for line in s:
+          f.write(line)
+        f.seek(0)
+        return f
+    else:
+        error("Unknown file to transfer for switch ",switch)
+        return None
+
   if not re.match('[A-Z]+[0-9][0-9]-[A-C]', switch):
     sw_reload(raddress)
     error("Switch", raddress, "does not match regexp, invalid option 82? Received ", option82, " as option 82")

--- a/swtftpd.py
+++ b/swtftpd.py
@@ -147,19 +147,30 @@ def file_callback(file_to_transfer, raddress, rport):
     if (model in config.models) and ('image' in config.models[model]):
       return file(config.models[model]['image'])
 
-  sw_type = db.get('type-%s' % raddress).decode()
+  sw_type = db.get('type-%s' % raddress)
+  if sw_type:
+    sw_type = sw_type.decode()
+
   if sw_type and sw_type == "ACCESS":
     if file_to_transfer.lower().endswith("-confg"):
-      with open(config.static_configs."/".switch.".txt") as s:
-        f = tempfile.TemporaryFile()
-        log("Sending static config for", raddress,"config =", switch)
-        for line in s:
-          f.write(line)
-        f.seek(0)
-        return f
-    else:
-        error("Unknown file to transfer for switch ",switch)
+      filename = config.static_configs + "/" + switch.lower() + ".txt"
+      try:
+        with open(filename, "rt") as s:
+          f = tempfile.TemporaryFile()
+          log("Sending static config for", raddress,"config =", switch)
+          for line in s:
+            f.write(line.encode())
+          f.seek(0)
+          return f
+      except FileNotFoundError as err:
+        error('File ', filename, ' not found')
         return None
+      except Exception as ex:
+        error('Uknown error occurred')
+        return None
+    else:
+          error("Unknown file to transfer for switch ",switch)
+          return None
 
   if not re.match('[A-Z]+[0-9][0-9]-[A-C]', switch):
     sw_reload(raddress)


### PR DESCRIPTION
### Feature : Allow swbooting of static configuration files
- The description of the interface must be formatted as follow : "ACCESS; <switch-short-hostname>"
- The folder from which the static file is loaded is defined in config.yml as the "static_config" option
- The dhcp-hooks.py stores the type of switch (TABLE or ACCESS) in the redis db.
- Keep 100% retro-compatibility with lan rows switchboot
- supported on swhttpd
- tested & working with juniper


### Bugfix : prevent crashes on restart
Often, when restarting the swhttpd daemon, the daemon would crash with error "Socket error: [Errno 98] Address already in use
".
By allowing for socket re-use, the daemon can now restart without having to wait <2 minutes for the kernel to release the previous socket.

### Change : Split "192.168.0.0/22" into 4x individual /24
This config seem specific to a past event and not needed anymore.